### PR TITLE
🎨 themeify css

### DIFF
--- a/build/split-css.js
+++ b/build/split-css.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+let fs = require('fs');
+var lines = fs
+  .readFileSync('./dist/styles.css', 'utf-8')
+  .split('\n')
+  .filter(Boolean);
+
+let cssVars = lines.slice(0, lines.indexOf('/*vars:end */'));
+let decls = lines.slice(lines.indexOf('/*vars:end */') + 1, lines.length);
+
+fs.writeFileSync('./dist/styles/kf-uikit-theme.css', cssVars.join('\n'), 'utf-8');
+fs.writeFileSync('./dist/styles/kf-uikit.css', decls.join('\n'), 'utf-8');

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Kids First Design System",
   "main": "dist/main.js",
   "module": "dist/main.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "dependencies": {
     "@storybook/react": "^3.4.10",
     "chroma-js": "^1.3.7",
@@ -43,6 +41,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "mini-css-extract-plugin": "^0.4.2",
     "optimize-css-assets-webpack-plugin": "^5.0.0",
+    "postcss-critical-split": "^2.5.2",
     "prettier": "^1.14.2",
     "react-docgen": "^2.21.0",
     "rollup": "^0.64.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chroma-js": "^1.3.7",
     "classnames": "^2.2.6",
     "lodash": "^4.17.10",
+    "postcss-to-css-vars": "https://github.com/kids-first/postcss-to-css-vars-plugin.git",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,10 @@
 module.exports = {
-    plugins: [
-        require('tailwindcss')('./tailwind.js')
-    ]
-}
+  plugins: [
+    require('tailwindcss')('./tailwind.js'),
+    require('postcss-to-css-vars')({
+      theme: './tailwind.js',
+      exclude: ['options', 'modules', 'plugins'],
+      prefix: 'KF',
+    }),
+  ],
+};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,6 +5,21 @@ module.exports = {
       theme: './tailwind.js',
       exclude: ['options', 'modules', 'plugins'],
       prefix: 'KF',
+      vocab: {
+        mt: 'margin',
+        mr: 'margin',
+        mb: 'margin',
+        ml: 'margin',
+        mx: 'margin',
+        my: 'margin',
+
+        pt: 'padding',
+        pr: 'padding',
+        pb: 'padding',
+        pl: 'padding',
+        px: 'padding',
+        py: 'padding',
+      },
     }),
   ],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
 import './tailwind.src.css';
-
-// Import components below

--- a/tailwind.js
+++ b/tailwind.js
@@ -26,7 +26,6 @@ View the full documentation at https://tailwindcss.com.
 
 // let defaultConfig = require('tailwindcss/defaultConfig')()
 
-
 /*
 |-------------------------------------------------------------------------------
 | Colors                                    https://tailwindcss.com/docs/colors
@@ -45,41 +44,82 @@ View the full documentation at https://tailwindcss.com.
 const chroma = require('chroma-js');
 
 let brand = {
-  'primary': '#90278e',
-  'secondary': '#2b388f',
-  'tertiary': '#009bb8',
-}
+  primary: '#90278e',
+  secondary: '#2b388f',
+  tertiary: '#009bb8',
+};
 
 shades = function(name, color) {
   return {
-    [`${name}-lightest`]: chroma(color).brighten(2.5).css(),
-    [`${name}-lighter`]: chroma(color).brighten(2.0).css(),
-    [`${name}-light`]: chroma(color).brighten(1.5).css(),
-    [`${name}`]: chroma(color).brighten().css(),
-    [`${name}-dark`]: chroma(color).darken(0.5).css(),
-    [`${name}-darker`]: chroma(color).darken(1.0).css(),
-    [`${name}-darkest`]: chroma(color).darken(1.5).css(),
-  }
-}
+    [`${name}-lightest`]: chroma(color)
+      .brighten(2.5)
+      .css(),
+    [`${name}-lighter`]: chroma(color)
+      .brighten(2.0)
+      .css(),
+    [`${name}-light`]: chroma(color)
+      .brighten(1.5)
+      .css(),
+    [`${name}`]: chroma(color)
+      .brighten()
+      .css(),
+    [`${name}-dark`]: chroma(color)
+      .darken(0.5)
+      .css(),
+    [`${name}-darker`]: chroma(color)
+      .darken(1.0)
+      .css(),
+    [`${name}-darkest`]: chroma(color)
+      .darken(1.5)
+      .css(),
+  };
+};
 
 let colors = {
-  'transparent': 'transparent',
+  transparent: 'transparent',
 
-  'black': '#22292f',
+  black: '#22292f',
   ...shades('grey', '#888888'),
-  'white': '#ffffff',
+  white: '#ffffff',
 
   ...shades('primary', brand.primary),
   ...shades('secondary', brand.secondary),
   ...shades('tertiary', brand.tertiary),
 
-  ...shades('info', chroma(brand.tertiary).brighten(1).css()),
+  ...shades(
+    'info',
+    chroma(brand.tertiary)
+      .brighten(1)
+      .css(),
+  ),
   ...shades('error', '#d8202f'),
-  ...shades('warn', chroma(brand.primary).brighten(1).css()),
-}
+  ...shades(
+    'warn',
+    chroma(brand.primary)
+      .brighten(1)
+      .css(),
+  ),
+};
+
+const spacingScale = {
+  px: '1px',
+  '0': '0',
+  '1': '.25rem',
+  '2': '.5rem',
+  '3': '.75rem',
+  '4': '1rem',
+  '5': '1.25rem',
+  '6': '1.5rem',
+  '8': '2rem',
+  '10': '2.5rem',
+  '12': '3rem',
+  '16': '4rem',
+  '20': '5rem',
+  '24': '6rem',
+  '32': '8rem',
+};
 
 module.exports = {
-
   /*
   |-----------------------------------------------------------------------------
   | Colors                                  https://tailwindcss.com/docs/colors
@@ -94,7 +134,6 @@ module.exports = {
   */
 
   colors: colors,
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -116,12 +155,11 @@ module.exports = {
   */
 
   screens: {
-    'sm': '576px',
-    'md': '768px',
-    'lg': '992px',
-    'xl': '1200px',
+    sm: '576px',
+    md: '768px',
+    lg: '992px',
+    xl: '1200px',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -142,24 +180,10 @@ module.exports = {
   */
 
   fonts: {
-    'title': [
-      'Montserrat',
-      'Helvetica Neue',
-      'sans-serif',
-    ],
-    'body': [
-      'Open Sans'
-    ],
-    'mono': [
-      'Menlo',
-      'Monaco',
-      'Consolas',
-      'Liberation Mono',
-      'Courier New',
-      'monospace',
-    ]
+    title: ['Montserrat', 'Helvetica Neue', 'sans-serif'],
+    body: ['Open Sans'],
+    mono: ['Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', 'monospace'],
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -181,17 +205,16 @@ module.exports = {
   */
 
   textSizes: {
-    'xs': '.75rem',     // 12px
-    'sm': '.875rem',    // 14px
-    'base': '1rem',     // 16px
-    'lg': '1.125rem',   // 18px
-    'xl': '1.25rem',    // 20px
-    '2xl': '1.5rem',    // 24px
-    '3xl': '1.875rem',  // 30px
-    '4xl': '2.25rem',   // 36px
-    '5xl': '3rem',      // 48px
+    xs: '.75rem', // 12px
+    sm: '.875rem', // 14px
+    base: '1rem', // 16px
+    lg: '1.125rem', // 18px
+    xl: '1.25rem', // 20px
+    '2xl': '1.5rem', // 24px
+    '3xl': '1.875rem', // 30px
+    '4xl': '2.25rem', // 36px
+    '5xl': '3rem', // 48px
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -208,17 +231,16 @@ module.exports = {
   */
 
   fontWeights: {
-    'hairline': 100,
-    'thin': 200,
-    'light': 300,
-    'normal': 400,
-    'medium': 500,
-    'semibold': 600,
-    'bold': 700,
-    'extrabold': 800,
-    'black': 900,
+    hairline: 100,
+    thin: 200,
+    light: 300,
+    normal: 400,
+    medium: 500,
+    semibold: 600,
+    bold: 700,
+    extrabold: 800,
+    black: 900,
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -233,12 +255,11 @@ module.exports = {
   */
 
   leading: {
-    'none': 1,
-    'tight': 1.25,
-    'normal': 1.5,
-    'loose': 2,
+    none: 1,
+    tight: 1.25,
+    normal: 1.5,
+    loose: 2,
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -253,11 +274,10 @@ module.exports = {
   */
 
   tracking: {
-    'tight': '-0.05em',
-    'normal': '0',
-    'wide': '0.05em',
+    tight: '-0.05em',
+    normal: '0',
+    wide: '0.05em',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -274,7 +294,6 @@ module.exports = {
 
   textColors: colors,
 
-
   /*
   |-----------------------------------------------------------------------------
   | Background colors             https://tailwindcss.com/docs/background-color
@@ -290,7 +309,6 @@ module.exports = {
 
   backgroundColors: colors,
 
-
   /*
   |-----------------------------------------------------------------------------
   | Background sizes               https://tailwindcss.com/docs/background-size
@@ -305,11 +323,10 @@ module.exports = {
   */
 
   backgroundSize: {
-    'auto': 'auto',
-    'cover': 'cover',
-    'contain': 'contain',
+    auto: 'auto',
+    cover: 'cover',
+    contain: 'contain',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -332,7 +349,6 @@ module.exports = {
     '8': '8px',
   },
 
-
   /*
   |-----------------------------------------------------------------------------
   | Border colors                     https://tailwindcss.com/docs/border-color
@@ -352,7 +368,6 @@ module.exports = {
 
   borderColors: global.Object.assign({ default: colors['grey-light'] }, colors),
 
-
   /*
   |-----------------------------------------------------------------------------
   | Border radius                    https://tailwindcss.com/docs/border-radius
@@ -370,13 +385,12 @@ module.exports = {
   */
 
   borderRadius: {
-    'none': '0',
-    'sm': '.125rem',
+    none: '0',
+    sm: '.125rem',
     default: '.25rem',
-    'lg': '.5rem',
-    'full': '9999px',
+    lg: '.5rem',
+    full: '9999px',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -399,8 +413,8 @@ module.exports = {
   */
 
   width: {
-    'auto': 'auto',
-    'px': '1px',
+    auto: 'auto',
+    px: '1px',
     '1': '0.25rem',
     '2': '0.5rem',
     '3': '0.75rem',
@@ -426,10 +440,9 @@ module.exports = {
     '4/5': '80%',
     '1/6': '16.66667%',
     '5/6': '83.33333%',
-    'full': '100%',
-    'screen': '100vw'
+    full: '100%',
+    screen: '100vw',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -447,8 +460,8 @@ module.exports = {
   */
 
   height: {
-    'auto': 'auto',
-    'px': '1px',
+    auto: 'auto',
+    px: '1px',
     '1': '0.25rem',
     '2': '0.5rem',
     '3': '0.75rem',
@@ -463,10 +476,9 @@ module.exports = {
     '32': '8rem',
     '48': '12rem',
     '64': '16rem',
-    'full': '100%',
-    'screen': '100vh'
+    full: '100%',
+    screen: '100vh',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -484,9 +496,8 @@ module.exports = {
 
   minWidth: {
     '0': '0',
-    'full': '100%',
+    full: '100%',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -504,10 +515,9 @@ module.exports = {
 
   minHeight: {
     '0': '0',
-    'full': '100%',
-    'screen': '100vh'
+    full: '100%',
+    screen: '100vh',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -525,18 +535,17 @@ module.exports = {
   */
 
   maxWidth: {
-    'xs': '20rem',
-    'sm': '30rem',
-    'md': '40rem',
-    'lg': '50rem',
-    'xl': '60rem',
+    xs: '20rem',
+    sm: '30rem',
+    md: '40rem',
+    lg: '50rem',
+    xl: '60rem',
     '2xl': '70rem',
     '3xl': '80rem',
     '4xl': '90rem',
     '5xl': '100rem',
-    'full': '100%',
+    full: '100%',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -553,10 +562,9 @@ module.exports = {
   */
 
   maxHeight: {
-    'full': '100%',
-    'screen': '100vh',
+    full: '100%',
+    screen: '100vh',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -573,24 +581,7 @@ module.exports = {
   |
   */
 
-  padding: {
-    'px': '1px',
-    '0': '0',
-    '1': '0.25rem',
-    '2': '0.5rem',
-    '3': '0.75rem',
-    '4': '1rem',
-    '5': '1.25rem',
-    '6': '1.5rem',
-    '8': '2rem',
-    '10': '2.5rem',
-    '12': '3rem',
-    '16': '4rem',
-    '20': '5rem',
-    '24': '6rem',
-    '32': '8rem',
-  },
-
+  padding: spacingScale,
 
   /*
   |-----------------------------------------------------------------------------
@@ -607,25 +598,7 @@ module.exports = {
   |
   */
 
-  margin: {
-    'auto': 'auto',
-    'px': '1px',
-    '0': '0',
-    '1': '0.25rem',
-    '2': '0.5rem',
-    '3': '0.75rem',
-    '4': '1rem',
-    '5': '1.25rem',
-    '6': '1.5rem',
-    '8': '2rem',
-    '10': '2.5rem',
-    '12': '3rem',
-    '16': '4rem',
-    '20': '5rem',
-    '24': '6rem',
-    '32': '8rem',
-  },
-
+  margin: Object.assign({}, spacingScale, { auto: 'auto' }),
 
   /*
   |-----------------------------------------------------------------------------
@@ -642,24 +615,23 @@ module.exports = {
   |
   */
 
-  negativeMargin: {
-    'px': '1px',
-    '0': '0',
-    '1': '0.25rem',
-    '2': '0.5rem',
-    '3': '0.75rem',
-    '4': '1rem',
-    '5': '1.25rem',
-    '6': '1.5rem',
-    '8': '2rem',
-    '10': '2.5rem',
-    '12': '3rem',
-    '16': '4rem',
-    '20': '5rem',
-    '24': '6rem',
-    '32': '8rem',
-  },
-
+  // negativeMargin: {
+  //   px: '1px',
+  //   '0': '0',
+  //   '1': '0.25rem',
+  //   '2': '0.5rem',
+  //   '3': '0.75rem',
+  //   '4': '1rem',
+  //   '5': '1.25rem',
+  //   '6': '1.5rem',
+  //   '8': '2rem',
+  //   '10': '2.5rem',
+  //   '12': '3rem',
+  //   '16': '4rem',
+  //   '20': '5rem',
+  //   '24': '6rem',
+  //   '32': '8rem',
+  // },
 
   /*
   |-----------------------------------------------------------------------------
@@ -679,13 +651,12 @@ module.exports = {
 
   shadows: {
     default: '0 2px 4px 0 rgba(0,0,0,0.10)',
-    'md': '0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
-    'lg': '0 15px 30px 0 rgba(0,0,0,0.11), 0 5px 15px 0 rgba(0,0,0,0.08)',
-    'inner': 'inset 0 2px 4px 0 rgba(0,0,0,0.06)',
-    'outline': '0 0 0 3px rgba(52,144,220,0.5)',
-    'none': 'none',
+    md: '0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
+    lg: '0 15px 30px 0 rgba(0,0,0,0.11), 0 5px 15px 0 rgba(0,0,0,0.08)',
+    inner: 'inset 0 2px 4px 0 rgba(0,0,0,0.06)',
+    outline: '0 0 0 3px rgba(52,144,220,0.5)',
+    none: 'none',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -701,7 +672,7 @@ module.exports = {
   */
 
   zIndex: {
-    'auto': 'auto',
+    auto: 'auto',
     '0': 0,
     '10': 10,
     '20': 20,
@@ -709,7 +680,6 @@ module.exports = {
     '40': 40,
     '50': 50,
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -732,7 +702,6 @@ module.exports = {
     '100': '1',
   },
 
-
   /*
   |-----------------------------------------------------------------------------
   | SVG fill                                   https://tailwindcss.com/docs/svg
@@ -748,9 +717,8 @@ module.exports = {
   */
 
   svgFill: {
-    'current': 'currentColor',
+    current: 'currentColor',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -767,9 +735,8 @@ module.exports = {
   */
 
   svgStroke: {
-    'current': 'currentColor',
+    current: 'currentColor',
   },
-
 
   /*
   |-----------------------------------------------------------------------------
@@ -816,7 +783,7 @@ module.exports = {
     maxWidth: ['responsive'],
     minHeight: ['responsive'],
     minWidth: ['responsive'],
-    negativeMargin: ['responsive'],
+    negativeMargin: false,
     opacity: ['responsive'],
     outline: ['focus'],
     overflow: ['responsive'],
@@ -841,7 +808,6 @@ module.exports = {
     zIndex: ['responsive'],
   },
 
-
   /*
   |-----------------------------------------------------------------------------
   | Plugins                                https://tailwindcss.com/docs/plugins
@@ -863,7 +829,6 @@ module.exports = {
     }),
   ],
 
-
   /*
   |-----------------------------------------------------------------------------
   | Advanced Options         https://tailwindcss.com/docs/configuration#options
@@ -879,5 +844,4 @@ module.exports = {
     important: false,
     separator: ':',
   },
-
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,6 +4252,12 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
+  dependencies:
+    is-buffer "~2.0.3"
+
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
@@ -5136,6 +5142,10 @@ is-binary-path@^1.0.0:
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-buffer@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -7651,6 +7661,15 @@ postcss-svgo@^4.0.0:
     postcss-value-parser "^3.0.0"
     svgo "^1.0.0"
 
+"postcss-to-css-vars@https://github.com/kids-first/postcss-to-css-vars-plugin.git":
+  version "0.0.0"
+  resolved "https://github.com/kids-first/postcss-to-css-vars-plugin.git#7f295fbe90e9c2d20a474bf62e63167fe9f0d920"
+  dependencies:
+    babel-polyfill "^6.26.0"
+    flat "^4.1.0"
+    lodash "^4.17.10"
+    postcss "^6.0.16"
+
 postcss-unique-selectors@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz#981d57d29ddcb33e7b1dfe1fd43b8649f933ca1d"
@@ -7696,7 +7715,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.17, postcss@^6.0.20, postcss@^6.0.21, postcss@^6.0.9:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.17, postcss@^6.0.20, postcss@^6.0.21, postcss@^6.0.9:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7178,6 +7178,13 @@ postcss-convert-values@^4.0.0:
     postcss "^6.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-critical-split@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/postcss-critical-split/-/postcss-critical-split-2.5.2.tgz#a6db5dc746a9c577c7cfbe77fe81404bdf1ea207"
+  dependencies:
+    merge "^1.2.0"
+    postcss "^6.0.1"
+
 postcss-discard-comments@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"


### PR DESCRIPTION
adds normalized-ish css custom property variables to the tailwind generated stylesheet to allow for granular design token overrides and custom themeing.

import the dist/styles.css
then add a theme.css with 
```css
:root{
   --KF-<variable_name>: <value_override>
}
```
to override vars and there dependent values