### PR TITLE
🐛 Add missing export for logo component

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,3 +2,4 @@ import './tailwind.src.css';
 
 // Import components below
 export Button from './components/Button/Button';
+export Logo from './components/Logo/Logo';


### PR DESCRIPTION
Components should be exported in `src/index.jsx` so that they are available in the library.