### PR TITLE
🐛 Add Header and Card to exports

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,3 +3,5 @@ import './tailwind.src.css';
 // Import components below
 export Button from './components/Button/Button';
 export Logo from './components/Logo/Logo';
+export Card from './components/Card/Card';
+export Header from './components/Header/Header';


### PR DESCRIPTION
Components need to be exported from index to be available to consuming apps.