### PR TITLE
🔧 Remove max-width constraint on cards

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -2,7 +2,6 @@
     @apply 
         inline-block
         overflow-hidden 
-        max-w-sm
         w-full
         m-2 
         p-4


### PR DESCRIPTION
Allows cards to be sized as needed by consumer.

## Before

<img width="1552" alt="screen shot 2018-10-17 at 1 46 44 pm" src="https://user-images.githubusercontent.com/2495894/47106226-0d5a4a00-d214-11e8-8029-17d777794b15.png">

## After

<img width="1552" alt="screen shot 2018-10-17 at 1 46 11 pm" src="https://user-images.githubusercontent.com/2495894/47106232-121efe00-d214-11e8-8993-383627824ed3.png">
