### PR TITLE
✅ Adds Percy.io Visual Testing to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       - run: yarn install
 
@@ -27,9 +27,8 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       # run tests!
       - run: ./node_modules/.bin/eslint src/
       - run: NODE_ENV=testing yarn test
-
-
+      - run: yarn snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.8
+      - image: circleci/node:10.8-browsers
 
     working_directory: ~/repo
 

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,10 +1,15 @@
 import React from 'react';
-import { configure, addDecorator } from '@storybook/react';
+import { configure, getStorybook, setAddon, addDecorator } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { checkA11y } from '@storybook/addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import centered from '@storybook/addon-centered';
+import createPercyAddon from '@percy-io/percy-storybook';
 import '../src/tailwind.src.css';
+
+const { percyAddon, serializeStories } = createPercyAddon();
+setAddon(percyAddon);
+
 
 addDecorator(
   withInfo({
@@ -34,3 +39,7 @@ function loadStories() {
 }
 
 configure(loadStories, module);
+
+serializeStories(getStorybook);
+
+

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,7 +3,13 @@
 
 
 <style>
+
 @media only percy {
+  /* set min-width for our stories so that components that are fill their container don't collapse */
+  .percy-min-width{
+    min-width: 960px;
+  }
+
   /* hide addon-info header, props table, and description from Percy test */
   #root > div > div > div > div:first-child,
   #root > div > div > div > div:last-child,
@@ -11,9 +17,9 @@
     display: none !important;
   }
   
-  .show-in-tests{
-    display: inline-block !important;
-  }
+  .show-in-tests{display: inline-block !important;}
+  /* show our color swatches a11y table to check for changes */
+  .ColorSwatch--a11y.hidden{display: block !important;}
 }
 
 

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,14 @@
-
-
 <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400|Open+Sans:400,500,700"
   rel="stylesheet">
+
+
+<style>
+@media only percy {
+  /* hide addon-info header, props table, and description from Percy test */
+  #root > div > div > div > div:first-child
+  #root > div > div > div > div:last-child,{
+    display: none;
+  }
+}
+
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,10 +5,16 @@
 <style>
 @media only percy {
   /* hide addon-info header, props table, and description from Percy test */
-  #root > div > div > div > div:first-child
-  #root > div > div > div > div:last-child,{
-    display: none;
+  #root > div > div > div > div:first-child,
+  #root > div > div > div > div:last-child,
+  .hide-in-tests{
+    display: none !important;
+  }
+  
+  .show-in-tests{
+    display: inline-block !important;
   }
 }
+
 
 </style>

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -2,7 +2,6 @@
 
 This document outlines the process for work on the Kids First Design system.
 
-
 ## Motivation
 
 It is important to maintain tight coupling of the artistic vision with the
@@ -13,18 +12,17 @@ brand, and heightened development costs to maintain.
 
 ## Process
 
-  1) A new component or change is designed using standard design tools
-  2) Feedback is given on the design and returned for modification
-  3) The design is accepted as final and interpreted as a spec for dev work
-  4) The spec is implemented into the design system by a developer
-  5) Developers and the designer provide feedback on its imlpementation
-  6) The imlpementation of the design is accepted and merged into the design system
-  7) Products that consume the design system may immediatly utilize the change
-
+1. A new component or change is designed using standard design tools
+2. Feedback is given on the design and returned for modification
+3. The design is accepted as final and interpreted as a spec for dev work
+4. The spec is implemented into the design system by a developer
+5. Developers and the designer provide feedback on its imlpementation
+6. The imlpementation of the design is accepted and merged into the design system
+7. Products that consume the design system may immediatly utilize the change
 
 ## An Example
 
-The default button style needs to be updated. 
+The default button style needs to be updated.
 
 ### Proposing a Change or New Component
 
@@ -64,11 +62,11 @@ It is thus vital that the presentation of the story be adequet for developer use
 
 The pull request will be reviewed based on:
 
-  - The implementation's consistency with the original design in the issue
-  - Sufficient documentation of the component in the storybook
-  - Conflict with other components and styles
-  - Code quality
-
+- The implementation's consistency with the original design in the issue
+- Sufficient documentation of the component in the storybook
+- Conflict with other components and styles
+  - visual diff checks in Percy.io to ensure there are no unintened side-affects to other components
+- Code quality
 
 ### Iteration on the Implementation
 

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "tailwind:css": "tailwind build src/css/tailwind.src.css -c  tailwind.js -o src/css/tailwind.css",
     "storybook": "NODE_ENV=testing start-storybook -p 9001 -c .storybook",
     "storybook:build": "NODE_ENV=testing build-storybook -c .storybook -o ./storybook-static/",
+    "snapshot": "yarn storybook:build && percy-storybook --widths=320,1280 --minimum_height=2000",
     "build": "NODE_ENV=production yarn run rollup -c",
     "test": "yarn run jest"
   },
   "devDependencies": {
     "@babel/runtime": "^7.0.0",
+    "@percy-io/percy-storybook": "^2.1.0",
     "@storybook/addon-a11y": "v4.0.0-alpha.18",
     "@storybook/addon-centered": "v4.0.0-alpha.18",
     "@storybook/addon-info": "v4.0.0-alpha.18",

--- a/src/components/Button/Button.story.jsx
+++ b/src/components/Button/Button.story.jsx
@@ -2,104 +2,46 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select } from '@storybook/addon-knobs';
+import { generateVariantsFor } from '../../utils/propsVariants';
 import Button from './Button';
 
 const stories = storiesOf('Buttons', module);
 
-stories.add('Default Button', () => (
-  <Button
-    size={select('Size', ['default', 'large'], 'default')}
-    color={select('Color', ['default', 'primary', 'secondary'], 'default')}
-    disabled={boolean('Disabled', false)}
-    type='button'
-  >
-    Click Me
-  </Button>
-  ),
+stories.add(
+  'Button',
+  () => {
+    const variants = generateVariantsFor({
+      size: ['default', 'large'],
+      color: ['default', 'primary', 'secondary'],
+      disabled: [true, false],
+    });
+    return (
+      <section>
+        <Button
+          className="hide-in-tests"
+          size={select('Size', ['default', 'large'], 'default')}
+          color={select('Color', ['default', 'primary', 'secondary'], 'default')}
+          disabled={boolean('Disabled', false)}
+          type="button"
+        >
+          Click Me
+        </Button>
+        <div className="show-in-tests hidden">
+          {variants.map(props => (
+            <Button className="m-20" {...props}>
+              Button&nbsp;
+              {Object.values(props).join(' ')}
+            </Button>
+          ))}
+        </div>
+      </section>
+    );
+  },
   {
-		info: {
+    info: {
       text: `
         The standard action button for most use cases in the portal.
-        `
+        `,
     },
-  }
-)
-
-
-stories.add('Primary Button', () => (
-  <Button
-    size={select('Size', ['default', 'large'], 'default')}
-    color={select('Color', ['default', 'primary', 'secondary'], 'primary')}
-    disabled={boolean('Disabled', false)}
-    type='button'
-  >
-    Click Me
-  </Button>
-  ),
-  {
-		info: {
-      text: `
-        To call attention to an action on a form, or highlight the strongest calls to action on a page.
-        `
-    },
-  }
-)
-
-
-stories.add('Secondary Button', () => (
-  <Button
-    size={select('Size', ['default', 'large'], 'default')}
-    color={select('Color', ['default', 'primary', 'secondary'], 'secondary')}
-    disabled={boolean('Disabled', false)}
-    type='button'
-  >
-    Click Me
-  </Button>
-  ),
-  {
-		info: {
-      text: `
-        Used sparingly for contrast from the primary buttons and an action to emphasize the most (usually contains an icon).
-        `
-    },
-  }
-)
-
-
-stories.add('Disabled Button', () => (
-  <Button
-    size={select('Size', ['default', 'large'], 'default')}
-    color={select('Color', ['default', 'primary', 'secondary'], 'default')}
-    disabled={boolean('Disabled', true)}
-    type='button'
-  >
-    Click Me
-  </Button>
-  ),
-  {
-		info: {
-      text: `
-        Used when another action has to be completed before the button is usable.
-        `
-    },
-  }
-)
-
-stories.add('Large Button', () => (
-  <Button
-    size={select('Size', ['default', 'large'], 'large')}
-    color={select('Color', ['default', 'primary', 'secondary'], 'default')}
-    disabled={boolean('Disabled', false)}
-    type='button'
-  >
-    Click Me
-  </Button>
-  ),
-  {
-		info: {
-      text: `
-        Buttons can have larger padding but default padding is used for most use cases. Large buttons are usually used to navigate to another page, should open in the current window unless the destination is an external site. 
-        `
-    },
-  }
-)
+  },
+);

--- a/src/components/Button/__tests__/Button-test.jsx
+++ b/src/components/Button/__tests__/Button-test.jsx
@@ -1,25 +1,21 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import {generateVariantsFor}   from '../../../utils/propsVariants';
+import {toPairs} from 'lodash';
 import Button from '../Button';
 
-['button', 'submit'].map((type) => {
-  ['default', 'large'].map((size) => {
-    [true, false].map((disabled) => {
-      ['default', 'primary', 'secondary'].map((c) => {
-        it(`${disabled ? 'disabled ' : ''}${size} ${c} ${type}}button renders correctly`, () => {
+const variants = generateVariantsFor({'size':['default', 'large'], 'color':  ['default', 'primary', 'secondary'], 'disabled': [true,false], 'type':['button', 'submit']});
+
+variants.map(props => {
+  
+  it(`Button ${toPairs(props).map(prop => `${prop[0]}:${prop[1]}, `)} renders correctly`, () => {
             const tree = renderer.create(
-                    <Button
-                      color={c}
-                      size={size}
-                      disabled={disabled}
-                      type={type}
-                    >
+                    <Button {...props}>
                       Hello
                     </Button>
                     ).toJSON();
               expect(tree).toMatchSnapshot();
         });
-      });
-    });
-  });
-});
+})
+
+        

--- a/src/components/Button/__tests__/__snapshots__/Button-test.jsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button-test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`default default button}button renders correctly 1`] = `
+exports[`Button size:default, ,color:default, ,disabled:false, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--default"
   disabled={false}
@@ -11,7 +11,7 @@ exports[`default default button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`default default submit}button renders correctly 1`] = `
+exports[`Button size:default, ,color:default, ,disabled:false, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--default"
   disabled={false}
@@ -22,51 +22,7 @@ exports[`default default submit}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`default primary button}button renders correctly 1`] = `
-<button
-  className="Button Button--default Button--primary"
-  disabled={false}
-  onClick={[Function]}
-  type="button"
->
-  Hello
-</button>
-`;
-
-exports[`default primary submit}button renders correctly 1`] = `
-<button
-  className="Button Button--default Button--primary"
-  disabled={false}
-  onClick={[Function]}
-  type="submit"
->
-  Hello
-</button>
-`;
-
-exports[`default secondary button}button renders correctly 1`] = `
-<button
-  className="Button Button--default Button--secondary"
-  disabled={false}
-  onClick={[Function]}
-  type="button"
->
-  Hello
-</button>
-`;
-
-exports[`default secondary submit}button renders correctly 1`] = `
-<button
-  className="Button Button--default Button--secondary"
-  disabled={false}
-  onClick={[Function]}
-  type="submit"
->
-  Hello
-</button>
-`;
-
-exports[`disabled default default button}button renders correctly 1`] = `
+exports[`Button size:default, ,color:default, ,disabled:true, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--default"
   disabled={true}
@@ -77,7 +33,7 @@ exports[`disabled default default button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`disabled default default submit}button renders correctly 1`] = `
+exports[`Button size:default, ,color:default, ,disabled:true, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--default"
   disabled={true}
@@ -88,7 +44,29 @@ exports[`disabled default default submit}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`disabled default primary button}button renders correctly 1`] = `
+exports[`Button size:default, ,color:primary, ,disabled:false, ,type:button,  renders correctly 1`] = `
+<button
+  className="Button Button--default Button--primary"
+  disabled={false}
+  onClick={[Function]}
+  type="button"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:default, ,color:primary, ,disabled:false, ,type:submit,  renders correctly 1`] = `
+<button
+  className="Button Button--default Button--primary"
+  disabled={false}
+  onClick={[Function]}
+  type="submit"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:default, ,color:primary, ,disabled:true, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--default Button--primary"
   disabled={true}
@@ -99,7 +77,7 @@ exports[`disabled default primary button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`disabled default primary submit}button renders correctly 1`] = `
+exports[`Button size:default, ,color:primary, ,disabled:true, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--default Button--primary"
   disabled={true}
@@ -110,7 +88,29 @@ exports[`disabled default primary submit}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`disabled default secondary button}button renders correctly 1`] = `
+exports[`Button size:default, ,color:secondary, ,disabled:false, ,type:button,  renders correctly 1`] = `
+<button
+  className="Button Button--default Button--secondary"
+  disabled={false}
+  onClick={[Function]}
+  type="button"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:default, ,color:secondary, ,disabled:false, ,type:submit,  renders correctly 1`] = `
+<button
+  className="Button Button--default Button--secondary"
+  disabled={false}
+  onClick={[Function]}
+  type="submit"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:default, ,color:secondary, ,disabled:true, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--default Button--secondary"
   disabled={true}
@@ -121,7 +121,7 @@ exports[`disabled default secondary button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`disabled default secondary submit}button renders correctly 1`] = `
+exports[`Button size:default, ,color:secondary, ,disabled:true, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--default Button--secondary"
   disabled={true}
@@ -132,73 +132,7 @@ exports[`disabled default secondary submit}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`disabled large default button}button renders correctly 1`] = `
-<button
-  className="Button Button--large"
-  disabled={true}
-  onClick={[Function]}
-  type="button"
->
-  Hello
-</button>
-`;
-
-exports[`disabled large default submit}button renders correctly 1`] = `
-<button
-  className="Button Button--large"
-  disabled={true}
-  onClick={[Function]}
-  type="submit"
->
-  Hello
-</button>
-`;
-
-exports[`disabled large primary button}button renders correctly 1`] = `
-<button
-  className="Button Button--large Button--primary"
-  disabled={true}
-  onClick={[Function]}
-  type="button"
->
-  Hello
-</button>
-`;
-
-exports[`disabled large primary submit}button renders correctly 1`] = `
-<button
-  className="Button Button--large Button--primary"
-  disabled={true}
-  onClick={[Function]}
-  type="submit"
->
-  Hello
-</button>
-`;
-
-exports[`disabled large secondary button}button renders correctly 1`] = `
-<button
-  className="Button Button--large Button--secondary"
-  disabled={true}
-  onClick={[Function]}
-  type="button"
->
-  Hello
-</button>
-`;
-
-exports[`disabled large secondary submit}button renders correctly 1`] = `
-<button
-  className="Button Button--large Button--secondary"
-  disabled={true}
-  onClick={[Function]}
-  type="submit"
->
-  Hello
-</button>
-`;
-
-exports[`large default button}button renders correctly 1`] = `
+exports[`Button size:large, ,color:default, ,disabled:false, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--large"
   disabled={false}
@@ -209,7 +143,7 @@ exports[`large default button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`large default submit}button renders correctly 1`] = `
+exports[`Button size:large, ,color:default, ,disabled:false, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--large"
   disabled={false}
@@ -220,7 +154,29 @@ exports[`large default submit}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`large primary button}button renders correctly 1`] = `
+exports[`Button size:large, ,color:default, ,disabled:true, ,type:button,  renders correctly 1`] = `
+<button
+  className="Button Button--large"
+  disabled={true}
+  onClick={[Function]}
+  type="button"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:large, ,color:default, ,disabled:true, ,type:submit,  renders correctly 1`] = `
+<button
+  className="Button Button--large"
+  disabled={true}
+  onClick={[Function]}
+  type="submit"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:large, ,color:primary, ,disabled:false, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--large Button--primary"
   disabled={false}
@@ -231,7 +187,7 @@ exports[`large primary button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`large primary submit}button renders correctly 1`] = `
+exports[`Button size:large, ,color:primary, ,disabled:false, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--large Button--primary"
   disabled={false}
@@ -242,7 +198,29 @@ exports[`large primary submit}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`large secondary button}button renders correctly 1`] = `
+exports[`Button size:large, ,color:primary, ,disabled:true, ,type:button,  renders correctly 1`] = `
+<button
+  className="Button Button--large Button--primary"
+  disabled={true}
+  onClick={[Function]}
+  type="button"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:large, ,color:primary, ,disabled:true, ,type:submit,  renders correctly 1`] = `
+<button
+  className="Button Button--large Button--primary"
+  disabled={true}
+  onClick={[Function]}
+  type="submit"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:large, ,color:secondary, ,disabled:false, ,type:button,  renders correctly 1`] = `
 <button
   className="Button Button--large Button--secondary"
   disabled={false}
@@ -253,10 +231,32 @@ exports[`large secondary button}button renders correctly 1`] = `
 </button>
 `;
 
-exports[`large secondary submit}button renders correctly 1`] = `
+exports[`Button size:large, ,color:secondary, ,disabled:false, ,type:submit,  renders correctly 1`] = `
 <button
   className="Button Button--large Button--secondary"
   disabled={false}
+  onClick={[Function]}
+  type="submit"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:large, ,color:secondary, ,disabled:true, ,type:button,  renders correctly 1`] = `
+<button
+  className="Button Button--large Button--secondary"
+  disabled={true}
+  onClick={[Function]}
+  type="button"
+>
+  Hello
+</button>
+`;
+
+exports[`Button size:large, ,color:secondary, ,disabled:true, ,type:submit,  renders correctly 1`] = `
+<button
+  className="Button Button--large Button--secondary"
+  disabled={true}
   onClick={[Function]}
   type="submit"
 >

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -12,13 +12,17 @@ stories.add('Simple Card', () => (
   </Card>
 ));
 
-stories.add('Many Cards', () => (
-  <div className="flex">
-    <Card className="flex-1" title="Card 1">
-      <p> Lorem ipsum </p>
-    </Card>
-    <Card className="flex-1" title="Card 2">
-      <p> Lorem ipsum </p>
-    </Card>
-  </div>
-));
+stories.add(
+  'Many Cards',
+  () => (
+    <div className="flex percy-min-width">
+      <Card className="flex-1" title="Card 1">
+        <p> Lorem ipsum </p>
+      </Card>
+      <Card className="flex-1" title="Card 2">
+        <p> Lorem ipsum </p>
+      </Card>
+    </div>
+  ),
+  { percy: { skip: true } },
+);

--- a/src/components/Header/Header.story.jsx
+++ b/src/components/Header/Header.story.jsx
@@ -10,9 +10,7 @@ const stories = storiesOf('Header', module);
 stories.addDecorator(withKnobs);
 
 stories.add('Header', () => (
-  <Header
-    buttons={[
-      <Button>Dashboard</Button>,
-      <Button outline>File Repository</Button>]}
-  />
+  <div className="percy-min-width">
+    <Header buttons={[<Button>Dashboard</Button>, <Button outline>File Repository</Button>]} />
+  </div>
 ));

--- a/src/components/Stats/Stats.story.jsx
+++ b/src/components/Stats/Stats.story.jsx
@@ -13,19 +13,18 @@ const stories = storiesOf('Stats', module);
 stories.add(
   'Stats Bar',
   () => (
-    <Stats
-      small={boolean('small', false)}
-      transparent={boolean('transparent', false)}
-      stats={object(
-        'stats',
-        [
+    <div className="percy-min-width">
+      <Stats
+        small={boolean('small', false)}
+        transparent={boolean('transparent', false)}
+        stats={object('stats', [
           { icon: 'file', label: 'Files', metric: 1000 },
           { icon: 'participant', label: 'Participants', metric: 1000 },
           { icon: 'family', label: 'Families', metric: 1000 },
           { icon: 'file-size', label: 'Size', metric: 1000 },
-        ],
-      )}
-    />
+        ])}
+      />
+    </div>
   ),
   {
     info: {

--- a/src/utils/propsVariants.js
+++ b/src/utils/propsVariants.js
@@ -1,0 +1,40 @@
+// source: https://github.com/evgenykochetkov/react-storybook-addon-props-combinations/blob/master/src/utils.js
+export const flatMap = (arr, fn) => arr.map(fn).reduce((a, b) => a.concat(b));
+
+/**
+ * Takes an object with a shape of {fieldName: arrayOfPossibleValues}
+ * and returns an array of objects with all possible combinations
+ * of field values
+ *
+ * eg: passing {foo: [1, 2], bar: ['a', 'b']} will return
+ * [
+ *  {foo: 1, bar: "a"},
+ *  {foo: 1, bar: "b"},
+ *  {foo: 2, bar: "a"},
+ *  {foo: 2, bar: "b"}
+ * ]
+ */
+export const generateVariantsFor = variationsByField => {
+  const fieldNames = Object.keys(variationsByField);
+
+  if (!fieldNames.length) return [{}];
+
+  const combinations = ([fieldName, ...restFieldNames], acc) => {
+    const variationsForField = variationsByField[fieldName];
+
+    if (!Array.isArray(variationsForField) || !variationsForField.length) {
+      throw new Error(`Please provide a non-empty array of possible values for prop ${fieldName}`);
+    }
+
+    const vs = variationsForField.map(fieldValue => ({ ...acc, [fieldName]: fieldValue }));
+
+    if (!restFieldNames.length) {
+      return vs;
+    } 
+    
+    return flatMap(vs, newAcc => combinations(restFieldNames, newAcc));
+    
+  };
+
+  return combinations(fieldNames, {});
+};

--- a/stories/Colors/Colors.jsx
+++ b/stories/Colors/Colors.jsx
@@ -6,8 +6,8 @@ import { compact, toPairs, omit } from 'lodash';
 
 const ColorValues = ({ color }) => (
   <small className="group inline-block h-full self-end text-right">
-    <p className='leading-tight'>{color.hex}</p>
-    <p className='leading-tight mt-0'>
+    <p className="leading-tight">{color.hex}</p>
+    <p className="leading-tight mt-0">
       rgb(
       {color.rgba.slice(0, 3).join(',')})
     </p>
@@ -36,15 +36,13 @@ function Swatch(props) {
         color == 'white' || color == 'lightGrey' ? 'black' : 'white'
       } px-12 leading-loose `}
     >
-      <small className="inline-block font-bold tracking-wide pb-4">
-        {color.toUpperCase()}
-      </small>
+      <small className="inline-block font-bold tracking-wide pb-4">{color.toUpperCase()}</small>
       <ColorValues color={colorData} />
     </div>
   );
 
   return (
-    <div className="container overflow-hidden w-1/3 p-20">
+    <div className="ColorSwatch container overflow-hidden w-1/3 p-20">
       <h3 className="text-center">{color}</h3>
       <div className="w-full overflow-hidden rounded-sm">{shades}</div>
 
@@ -58,7 +56,7 @@ function Swatch(props) {
           </span>
           <span className="inline-block leading-normal float-right">{idealTextColor[1]}</span>
         </small>
-        <div className="hidden group-hover:block">
+        <div className="ColorSwatch--a11y hidden group-hover:block">
           {textColors.map(colorArr => (
             <small
               className={`block w-full h-8  p-4 bg-${colorData.key} text-black text-${colorArr[0]}`}

--- a/stories/Colors/Colors.story.jsx
+++ b/stories/Colors/Colors.story.jsx
@@ -12,24 +12,12 @@ const storyInfo = {
 
 const brand = ['blue', 'purple', 'teal', 'lightBlue', 'lightGrey', 'darkGrey'];
 const brandSwatches = brand.map(color => <Swatch color={color} />);
-stories.add(
-  'Primary',
-  () => (
-    <div className="flex flex-wrap">
-      {brandSwatches}
-    </div>
-  ),
-  storyInfo,
-);
+stories.add('Primary', () => <div className="flex flex-wrap">{brandSwatches}</div>, storyInfo);
 
 const secondary = ['pink', 'red', 'orange', 'mediumGrey'];
 const secondarySwatches = secondary.map(color => <Swatch color={color} />);
 stories.add(
   'Secondary',
-  () => (
-    <div className="flex flex-wrap">
-      {secondarySwatches}
-    </div>
-  ),
+  () => <div className="flex flex-wrap">{secondarySwatches}</div>,
   storyInfo,
 );

--- a/stories/Spacing/Spacing.story.jsx
+++ b/stories/Spacing/Spacing.story.jsx
@@ -19,7 +19,7 @@ stories.add(
   'spacing values',
   () => (
     <section className="container relative w-full mx-32 flex flex-wrap">
-      <header className="w-2/3 inline-block float-left">
+      <header className="w-2/3 inline-block float-left hide-in-tests">
         <h2 className="pb-8">
           All Spacing (margin, padding) css classes utilize the{' '}
           <a taget="_blank" href="https://tailwindcss.com/docs/spacing/#app">
@@ -32,8 +32,8 @@ stories.add(
           Consistent spacing creates visual balance and mathematical harmony that makes the user
           interface (UI) easier to scan. All spacing for components and typography is done in
           increments of 4 pixels using rem values,{' '}
-          <code className="bg-lightGrey text-sm p-4">1rem = 14px to 16px</code>{' '} 
-          on the same fluid scale used for typography. This 4px value forms the basic unit of measurement for spacing.
+          <code className="bg-lightGrey text-sm p-4">1rem = 14px to 16px</code> on the same fluid
+          scale used for typography. This 4px value forms the basic unit of measurement for spacing.
           Therefore, 4 is the magic number in all of our rules. It drives how column layouts are
           determined, elements are designed, how components interact with each other. The success of
           a digital design system lies in the intelligence of its math.
@@ -49,13 +49,11 @@ stories.add(
             <th>px</th>
           </thead>
           <tbody>
-            {toPairs(tailwind.margin).map((spacing) => (
+            {toPairs(tailwind.margin).map(spacing => (
               <tr className="border-b">
-                <td>{spacing[0]}</td> 
+                <td>{spacing[0]}</td>
                 <td className="text-xs">{spacing[1].replace('rem', '')}</td>
-                <td> 
-                  {+spacing[1].replace('rem', '') * 16} 
-                 </td>
+                <td>{+spacing[1].replace('rem', '') * 16}</td>
               </tr>
             ))}
           </tbody>
@@ -70,8 +68,8 @@ stories.add(
             padding values (.p-N)
           </a>
           <br />
-          <small className="text-grey ">4px x 4px cells</small> 
-            &nbsp;
+          <small className="text-grey ">4px x 4px cells</small>
+          &nbsp;
           <small>
             <span className="inline-block bg-red opacity-75" style={{ width: 8, height: 8 }} />
             padding box &nbsp;
@@ -84,7 +82,7 @@ stories.add(
         </h3>
 
         <section className="w-full relative flex flex-wrap" style={{ height: 275 }}>
-          {[4, 8, 12, 16, 20, 32, 40, 60].map((i) => (
+          {[4, 8, 12, 16, 20, 32, 40, 60].map(i => (
             <div
               className={`flex items-center content-center text-center relative z-10 mr-${i} p-${i} ${
                 i === 4 ? 'ml-12' : null
@@ -92,7 +90,7 @@ stories.add(
               style={{ width: i * 3, height: i * 3 }}
             >
               <span className="w-full h-full bg-lightBlue" />
-              <span style={{ fontSize: 12, bottom: -20 }} className="absolute pin-l pin-b" >
+              <span style={{ fontSize: 12, bottom: -20 }} className="absolute pin-l pin-b">
                 {i}
               </span>
             </div>
@@ -103,16 +101,15 @@ stories.add(
 
       <div className="relative overflow-hidden w-1/3 mb-16 text-sm" style={{ height: 175 }}>
         <h3 className="z-20">
-          
           <a target="_blank" href="https://tailwindcss.com/docs/spacing/#app">
             margin right values (.mr-N)
           </a>
-          <br /> 
+          <br />
           <small className="text-grey">4px x 4px cells</small>
         </h3>
 
         <section className="w-full relative flex flex-wrap">
-          {[4, 8, 12, 16, 20, 32, 40, 60].map((i) => (
+          {[4, 8, 12, 16, 20, 32, 40, 60].map(i => (
             <div
               className={`flex items-center content-center text-center relative z-10 mr-${i} ${
                 i === 4 ? 'ml-12' : null
@@ -130,16 +127,14 @@ stories.add(
 
       <div className="relative overflow-hidden w-1/3 pl-40 mb-16" style={{ height: 175 }}>
         <h3 className="z-20">
-          Large Button 
-          <br /> 
+          Large Button
+          <br />
           <small className="text-grey">4px x 4px cells</small>
         </h3>
 
         <section className="w-full relative flex flex-wrap">
-          <button className="Button Button--large Button--secondary m-20">
-            Large Button HERE
-          </button>
-          <FourPxGrid  />
+          <button className="Button Button--large Button--secondary m-20">Large Button HERE</button>
+          <FourPxGrid />
         </section>
       </div>
     </section>

--- a/stories/Typography/Typography.story.jsx
+++ b/stories/Typography/Typography.story.jsx
@@ -27,88 +27,42 @@ stories.add(
     <div>
       <section className="container mx-auto">
         <p>
-          The aim of the uikit's typographic system is to prioritize and optimize readability across
-          viewport sizes while maintaining relationships and heirarchies to preserve infomation
-          structures. Therefore, all <code className="bg-lightGrey text-sm p-4">font-size</code>{' '}
-          values are set to{' '}
+          The aim of the uikit's typographic system is to maximize readability across all viewport
+          sizes while maintaining size and relationship heirarchies to preserve infomation
+          structures. Therefore, all font sizing for the uikit is based on{' '}
           <a href="https://www.sitepoint.com/understanding-and-using-rem-units-in-css/">rem </a>{' '}
-          values instead of discrete pixel sizes. The corresponding rem to pixel values can be found
-          in the table below.
+          values instead of discrete pixel sizes.
         </p>
-        <h3>rem to px values table</h3>
-        <table className="table-fixed text-center bg-lightGrey" style={{ width: 600 }}>
-          <thead>
-            <th>viewport width</th>
-            <th>media query</th>
-            <th>value of 1rem</th>
-          </thead>
-          <tbody>
-            <tr className="border-b">
-              <td> &lt; 576px</td>
-              <td />
-              <td>14px</td>
-            </tr>
-            <tr className="border-b">
-              {' '}
-              <td> &lt; 768px and &gt; 576px </td>
-              <td>@media (min-width: 576px) and (max-width: 768px) </td>
-              <td>between 14 and 16px</td>{' '}
-            </tr>
-            <tr className="border-b">
-              {' '}
-              <td>&gt; 768px </td>
-              <td>@media (min-width: 768px)</td>
-              <td>16px</td>{' '}
-            </tr>
-          </tbody>
-        </table>
-        <hr />
         <h3 className="mt-16">The Perils of Pixels</h3>
         <p>
-          When <code className="bg-lightGrey text-sm p-4">font-size</code> is set to explicit values{' '}
-          (ex. <code className="bg-lightGrey text-sm p-4">font-size: 16px;</code> ) it forces us
-          take an adaptive approach where we must then set the font-size to a explicit value at each
-          responsive breakpoint. This method renders a sub-optimal user experience as it causes
-          jumps/quick snaps in font-size between breakpoints, as seen below.
+          When font-sizing is set to discrete and rigid pixel values{' '}
+          <code className="bg-lightGrey text-sm p-4">font-size: 16px;</code>
+          it forces us take an adaptive approach where we must then set the font-size to a discrete
+          value at each responsive breakpoint. This method renders a sub-optimal user experience as
+          it causes jumps/quick snaps between font sizes at the different font-sizes as seen below.
+          <figure>
+            <img src={mediaQueryOpt} alt="" />
+            <caption className="block w-full text-xs text-left">
+              source:{' '}
+              <a href="https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/">
+                Smashing Magazine
+              </a>{' '}
+            </caption>
+          </figure>
         </p>
-        <figure>
-          <img src={mediaQueryOpt} alt="" />
-          <caption className="block w-full text-xs text-left">
-            source:{' '}
-            <a href="https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/">
-              Smashing Magazine
-            </a>{' '}
-          </caption>
-        </figure>
-
-        <h3 className="mt-16">Rescued by rem</h3>
+        <h3 className="mt-16">Molten Leading Technique</h3>
         <p>
-          Using the root-em, <code className="bg-lightGrey text-sm p-4">rem</code>, as our basic
-          unit of measure for font-size we are able to take a truly fluid and responsive approach to
-          font and spacing values. This allows us to set values in terms of percentages of 1 rem
-          (ex. <code className="bg-lightGrey text-sm p-4">1rem = 14px; 0.5rem = 1/2rem = 7px;</code>
-          ). By setting the rem value in our css{' '}
-          <code
-            className="bg-lightGrey text-sm p-4"
-            dangerouslySetInnerHTML={{ __html: `:root{ }` }}
-          />
-          , which the top-most parent in the css cascade, we are able to leverage css'{' '}
-          <code className="bg-lightGrey text-sm p-4">calc()</code>, which executes upon each browser
-          resize, to fluidly adjust the rem size based on viewport width and thus proportionately
-          scale all rem based values throughout our design system.
-        </p>
-
-        <h3 className="pt-16">Molten Leading Technique</h3>
-        <p>
-          This clever fluid scaling effect is accomplished using the css calc formula proposed by
-          the
+          When using the
+          <code className="bg-lightGrey text-sm p-4">rem</code>
+          as our basic unit for font sizing and breakpoints we are able to take a truly fluid
+          responsive approach to font and spacing values using the{' '}
           <a
             href="https://www.madebymike.com.au/writing/precise-control-responsive-typography/"
             target="_blank"
           >
             Molten Leading technique
           </a>
-          . This technique utilizes a combination of{' '}
+          . This technique uses a combination of{' '}
           <code className="bg-lightGrey text-sm p-4">vw</code>(
           <a
             href="https://css-tricks.com/viewport-sized-typography/#article-header-id-1"
@@ -116,24 +70,24 @@ stories.add(
           >
             viewport units
           </a>
-          ) range and font-size range to calculate a scaling factor for our :root rem value. This
-          results in all rem defined values scaling proportionately with the viewport/browser size
-          as seen below.
+          ) and rem in relation to line-width and line-height/leading to calculate the appropriate
+          rem size to viewport size relationship. This results in the rem value scaling
+          appropriately with the viewport size as seen below.
+          <figure>
+            <img src={viewportOpt} alt="" />
+            <caption className="block w-full text-xs text-left">
+              source:{' '}
+              <a href="https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/">
+                Smashing Magazine
+              </a>{' '}
+            </caption>
+          </figure>
         </p>
-        <figure>
-          <img src={viewportOpt} alt="" />
-          <caption className="block w-full text-xs text-left">
-            source:{' '}
-            <a href="https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/">
-              Smashing Magazine
-            </a>{' '}
-          </caption>
-        </figure>
-
-        <h4 className="mt-20">Precise control over rem size</h4>
+        <h4>Precise control over rem size</h4>
         <p>
           We don't want our font size to infinitely scale as it would then become unreasonably large
-          or small. Therefore to limit the font scaling we use a combination of css
+          or small. Therefore we use media queries to limit the font scaling with a combination of
+          css
           <code className="bg-lightGrey text-sm p-4">calc()</code>
           and media queries. <br />
           <code
@@ -152,9 +106,9 @@ stories.add(
           />
         </p>
         <p>
-          By combining media queries and vw units we are able to get a triadic formula by which
-          scale the rem value between a specific range of viewport sizes.
-          <code className="w-full block bg-lightGrey font-bold p-4 text-sm">
+          Using this techinque we can cap our rem value to a maximum and minimum pixel value at
+          specific viewport widths using this formula.
+          <code className="w-full block bg-lightGrey font-bold p-4">
             {' '}
             font-size: calc($min_font_px + ($max_font - $min_font) * ( (100vw - $min_width_px) / (
             $max_width - $min_width)));
@@ -165,8 +119,7 @@ stories.add(
               CSS Tricks: Molten Leading article
             </a>
           </small>{' '}
-        </p>
-        <p className="bg-lightGrey border p-12">
+          <br />
           To experiment with this technique in order to get a better grasp of the concepts at play
           please checkout this{' '}
           <a href="https://codepen.io/MadeByMike/pen/YPJJYv" target="_blank">
@@ -181,6 +134,33 @@ stories.add(
           set other values such as margin and padding using rem values so that they are in proper
           porportion to our typography giving our UIs consistent vertical and horizontal rhythm.
         </p>
+        <h2 className="mt-16">uikit values</h2>
+        <table className="table-fixed text-center bg-lightGrey" style={{ width: 600 }}>
+          <thead>
+            <th>viewport width</th>
+            <th>media query</th>
+            <th>value of 1rem</th>
+          </thead>
+          <tbody>
+            <tr className="border-b">
+              <td> &lt; 320px</td>
+              <td>none</td>
+              <td>14px</td>
+            </tr>
+            <tr className="border-b">
+              {' '}
+              <td> &gt; 320px &lt; 544px</td>
+              <td>min-width: 20em</td>
+              <td>&gt; 14px &lt; 16px </td>{' '}
+            </tr>
+            <tr className="border-b">
+              {' '}
+              <td>&gt; 544px </td>
+              <td>min-width: 80em</td>
+              <td>16px</td>{' '}
+            </tr>
+          </tbody>
+        </table>
 
         <h5 className="mt-20">further reading:</h5>
         <ul>
@@ -238,7 +218,7 @@ stories.add(
       </section>
     </div>
   ),
-  { info: { source: false } },
+  { info: { source: false }, percy: { skip: true } },
 );
 
 stories.add('Type Specimen', () => (
@@ -317,11 +297,12 @@ stories.add('Type Specimen', () => (
   </div>
 ));
 
-stories.add('h1', () => <h1>{text('h1 text', 'Heading h1')}</h1>);
-stories.add('h2', () => <h2>{text('h2 text', 'Heading h2')}</h2>);
-stories.add('h3', () => <h3>{text('h3 text', 'Heading h3')}</h3>);
-stories.add('h4', () => <h4>{text('h4 text', 'Heading h4')}</h4>);
-stories.add('h5', () => <h5>{text('h5 text', 'Heading h5')}</h5>);
+stories.add('h1', () => <h1>{text('h1 text', 'Heading h1')}</h1>, { percy: { skip: true } });
+stories.add('h2', () => <h2>{text('h2 text', 'Heading h2')}</h2>, { percy: { skip: true } });
+stories.add('h3', () => <h3>{text('h3 text', 'Heading h3')}</h3>, { percy: { skip: true } });
+stories.add('h4', () => <h4>{text('h4 text', 'Heading h4')}</h4>, { percy: { skip: true } });
+stories.add('h5', () => <h5>{text('h5 text', 'Heading h5')}</h5>, { percy: { skip: true } });
+
 const loremIpsum = `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
       invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et
       justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
@@ -338,17 +319,22 @@ stories.add('Paragraph', () => <p className="pl-10">{text('paragraph text', lore
     text: `In order to preserve optimal readability paragraph line length is capped at around 45-75 characters (30em) including spaces and punctuation.
     This spacing is set to be fluid and adjust according to viewport width calculations based on recommendations from https://css-tricks.com/molten-leading-css/`,
   },
+  percy: { skip: true },
 });
 
-stories.add('Blockquote', () => (
-  <blockquote>
-    {text(
-      'quote',
-      `Contingent on available funds, the DRC award is expected to provide funding for five years of up
+stories.add(
+  'Blockquote',
+  () => (
+    <blockquote>
+      {text(
+        'quote',
+        `Contingent on available funds, the DRC award is expected to provide funding for five years of up
     to a total of approximately $14.8 million.`,
-    )}
-  </blockquote>
-));
+      )}
+    </blockquote>
+  ),
+  { percy: { skip: true } },
+);
 
 stories.add('un-ordered list', () => (
   <ul>
@@ -376,12 +362,16 @@ stories.add('ordered list', () => (
   </ol>
 ));
 
-stories.add('horizontal rule', () => (
-  <div>
-    <p>{loremIpsum.slice(0, 200)}</p>
-    <hr />
-    <p>{loremIpsum.slice(0, 250)}</p>
-    <hr />
-    <p>{loremIpsum}</p>
-  </div>
-));
+stories.add(
+  'horizontal rule',
+  () => (
+    <div>
+      <p>{loremIpsum.slice(0, 200)}</p>
+      <hr />
+      <p>{loremIpsum.slice(0, 250)}</p>
+      <hr />
+      <p>{loremIpsum}</p>
+    </div>
+  ),
+  { percy: { skip: true } },
+);


### PR DESCRIPTION
Runs visual regression testing on all builds and PRs

### Motivation

We want to make sure that code changes made to isolated components don't have adverse effects on the whole system. Visual testing complements our existing unit and integration tests to verify that our entire UI–including components–aren’t just functioning correctly, but are also free of visual bugs or regressions.

### Use Cases
On each commit we push to a PR we want to kickoff CI and [compare a visual diff of our new stories to the base branches stories](https://docs.percy.io/docs/baseline-picking-logic) to ensure we changed all we intended and nothing that we didn't. This wil also help to scale the design system to a federated model so developers and designers alike can contribute with the security of knowing their contributions are tested and follow standards. 


### API changes
add npm script `"snapshot": "yarn storybook:build && percy-storybook --widths=320,1280 --minimum_height=2000"`

### Implementation Notes
This adds several [percy specific classes](https://docs.percy.io/docs/percy-specific-css) to hide non-essentail elements from rendering and being tested in percy snapshots. 

```css
@media only percy {
  /* set min-width for our stories so that components that are fill their container don't collapse */
  .percy-min-width{
    min-width: 960px;
  }

  /* hide addon-info header, props table, and description from Percy test */
  #root > div > div > div > div:first-child,
  #root > div > div > div > div:last-child,
  .hide-in-tests{
    display: none !important;
  }
  
  .show-in-tests{display: inline-block !important;}
  /* show our color swatches a11y table to check for changes */
  .ColorSwatch--a11y.hidden{display: block !important;}
}
```

### Rendering and Storybook location
Percy picks up and renders every story in Storybook by default. 
🚧  🚧 🚧 
I have attempted to hide some stories by using the percy story parameter `{ percy: {skip: true} }` on individual stories. However, this has not worked thus far and will be addressed with an upgrade to storybook v5 and percy v3
🚧  🚧 🚧 

### Functional Tests
Special test cases for percy only:
- render all button props combinations 
- render color swatches a11y tables open to check for changes 
- set header and card stories to a min-width of 960px in percy tests so they don't collapse
