### PR TITLE
♻️ Make header hoverable

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -19,12 +19,12 @@ const Header = ({ buttons, logo, children }) => {
   const navClass = className(
     'Header--navigation',
   );
-
+  const logoClass = className('Header--logo', { 'cursor-pointer': logoHref || onLogoClick });
   return (
     <header className='Header'>
       <nav className={navClass}>
         <a href={logoHref} onClick={() => onLogoClick()}>
-          <Logo className='Header--logo' />
+          <Logo className={logoClass} />
         </a>
         <div className='Navigation--buttons'>
           {buttons ? buttons.map(button => button) : null}

--- a/src/components/Header/__tests__/__snapshots__/Header-tests.jsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header-tests.jsx.snap
@@ -16,7 +16,7 @@ exports[`navigation renders correctly 1`] = `
       >
         <img
           alt="Kids First Data Resource Center logo"
-          className="Header--logo Logo--img"
+          className="Header--logo cursor-pointer Logo--img"
           src="test-file-stub"
         />
         <h1


### PR DESCRIPTION
Add hover class (cursor-pointer) to header logo when `logoHref` or `onLogoClick` exists.

Fixes #97 