### PR TITLE
✨ Add SecondaryNav component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -34,6 +34,7 @@ let req = {
   cards: './src/components/Card/Card.story.jsx',
   header: './src/components/Header/Header.story.jsx',
   stats: './src/components/Stats/Stats.story.jsx',
+  navigation: './src/components/SecondaryNav/SecondaryNav.story.jsx',
 };
 const storyReqs = require.context('../', true, /^.*\.story\.jsx$/);
 

--- a/src/components/SecondaryNav/SecondaryNav.css
+++ b/src/components/SecondaryNav/SecondaryNav.css
@@ -1,0 +1,53 @@
+.SecondaryNav {
+  @apply border-b-2
+      relative
+      bg-white
+      overflow-hidden
+      border-mediumGrey;
+}
+
+.SecondaryNav ul {
+  @apply p-0
+      m-0
+      relative
+      inline-block
+      h-full
+      max-w-full;
+}
+
+.SecondaryNav--link {
+  @apply m-0
+      p-0
+      relative
+      inline-block
+      h-full
+      border-lightGrey
+      border
+      border-b-0
+      font-semibold
+      cursor-pointer;
+
+  a {
+    @apply p-16
+              block
+              h-full
+              text-sm
+              font-semibold
+              text-purple
+              text-center
+              font-title
+              no-underline;
+    &:focus {
+      @apply text-pink
+            border-b-4
+            border-pink;
+    }
+  }
+}
+
+.SecondaryNav--link:hover a,
+.SecondaryNav--link-active a {
+  @apply text-pink
+      border-b-4
+      border-pink;
+}

--- a/src/components/SecondaryNav/SecondaryNav.jsx
+++ b/src/components/SecondaryNav/SecondaryNav.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import classes from 'classnames';
+/**
+ * Secondary navigation typically used under the header
+ *
+ * Must pass an array of NavLinks for the navigation bar.
+ * Each SecondaryNavLink can take active, onNavClick as props, and {tabText}
+ * as children.
+ * `<SecondaryNavLink key={key} active={ifActive} onNavClick={() => {}} href={herf}>`
+ * `{tabText}`
+ * `</SecondaryNavLink>`
+ */
+const SecondaryNav = ({ buttons, className }) => {
+  const navClass = classes('SecondaryNav', className);
+  return (
+    <nav className={navClass}>
+      <ul className="SecondaryNav--list">{buttons ? buttons.map(button => button) : null}</ul>
+    </nav>
+  );
+};
+
+SecondaryNav.propTypes = {
+  /** Any additional classes to be applied to secondary navbar */
+  className: propTypes.string,
+  /** NavLinks to display on the navbar */
+  buttons: propTypes.node,
+};
+
+SecondaryNav.defaultProps = {
+  className: null,
+  buttons: null,
+};
+
+export default SecondaryNav;

--- a/src/components/SecondaryNav/SecondaryNav.story.jsx
+++ b/src/components/SecondaryNav/SecondaryNav.story.jsx
@@ -1,0 +1,43 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, array } from '@storybook/addon-knobs';
+import SecondaryNav from './SecondaryNav';
+import SecondaryNavLink from './SecondaryNavLink';
+
+const stories = storiesOf('SecondaryNav', module);
+
+stories.addDecorator(withKnobs);
+
+stories.add(
+  'SecondaryNav',
+  () => {
+    const navList = array('Array of Tab Name', ['Tab1', 'Tab2', 'Tab3']);
+    return (
+      <div className="percy-min-width">
+        <SecondaryNav
+          buttons={navList.map(i => (
+            <SecondaryNavLink
+              key={i}
+              active={navList.indexOf(i) === 0}
+              onNavClick={e => {
+                e.preventDefault();
+              }}
+              href="/"
+            >
+              {i}
+            </SecondaryNavLink>
+          ))}
+        />
+      </div>
+    );
+  },
+  {
+    info: {
+      text: `
+        The secondary nav is typically displayed below the primary navigation
+        at the header of the site.
+          `,
+    },
+  },
+);

--- a/src/components/SecondaryNav/SecondaryNavLink.jsx
+++ b/src/components/SecondaryNav/SecondaryNavLink.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import classes from 'classnames';
+/**
+ * A navigation link item to be used inside the secondary nav bar
+ *
+ */
+const SecondaryNavLink = ({ href, active, children, onNavClick, className }) => {
+  const linkClass = classes(
+    ['SecondaryNav--link', { 'SecondaryNav--link-active': active }],
+    className,
+  );
+  return (
+    <li className={linkClass}>
+      <a href={href} onClick={onNavClick}>
+        {children}
+      </a>
+    </li>
+  );
+};
+
+SecondaryNavLink.propTypes = {
+  /** Any additional classes to be applied to secondary navbar button */
+  className: propTypes.string,
+  /** Child elements to display on the navbar */
+  children: propTypes.node,
+  /** The url to navigate to */
+  href: propTypes.string,
+  /** A function to perform onClick */
+  onNavClick: propTypes.func,
+  /** Whether the link is active */
+  active: propTypes.bool,
+};
+
+SecondaryNavLink.defaultProps = {
+  className: null,
+  children: null,
+  active: false,
+  onNavClick: () => {},
+  href: null,
+};
+
+export default SecondaryNavLink;

--- a/src/components/SecondaryNav/__tests__/SeconadryNav-tests.jsx
+++ b/src/components/SecondaryNav/__tests__/SeconadryNav-tests.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import SecondaryNav from '../SecondaryNav';
+import SecondaryNavLink from '../SecondaryNavLink';
+
+it(`secondary navigation renders correctly`, () => {
+  const tree = renderer
+    .create(
+      <SecondaryNav
+        buttons={[
+          <SecondaryNavLink key={1} href="/">
+            Testing
+          </SecondaryNavLink>,
+        ]}
+      />,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/SecondaryNav/__tests__/__snapshots__/SeconadryNav-tests.jsx.snap
+++ b/src/components/SecondaryNav/__tests__/__snapshots__/SeconadryNav-tests.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`secondary navigation renders correctly 1`] = `
+<nav
+  className="SecondaryNav"
+>
+  <ul
+    className="SecondaryNav--list"
+  >
+    <li
+      className="SecondaryNav--link"
+    >
+      <a
+        href="/"
+        onClick={[Function]}
+      >
+        Testing
+      </a>
+    </li>
+  </ul>
+</nav>
+`;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,3 +8,4 @@ export Header from './components/Header/Header';
 export Icon from './components/Icon/Icon';
 export Stats from './components/Stats/Stats';
 export GridContainer from './components/Grid/GridContainer';
+export SecondaryNav from './components/SecondaryNav/SecondaryNav';


### PR DESCRIPTION
### Motivation

The secondary nav is typically displayed below the primary navigation at the header of the site.
![image](https://user-images.githubusercontent.com/32206137/55743280-e8df6d80-59ff-11e9-8b90-4e98b769905d.png)

### Use Cases

Because the primary navigation's intent is to stay consistent across Kids First applications, the secondary navigation will house much of an applications navigation content. Examples:

- Kids First Data Tracker
![image](https://user-images.githubusercontent.com/32206137/55743384-2643fb00-5a00-11e9-9e64-2c5900efa1ed.png)
- Kids First website
![image](https://user-images.githubusercontent.com/2495894/48369612-114b8180-e685-11e8-81c0-f16dce6bba1e.png)
- Release Archives [Study Archives, Release Archives]

### API changes

No API changes are made on this component.

### Implementation Notes

An example of how to pass buttons props to the SecondaryNav component:
```
<SecondaryNav
    buttons={[
      <NavLink active key={1}><a href="/">Dashboard</a></NavLink>,
      <NavLink key={2}><a href="/">File Repository</a></NavLink>]}
  />
```

### Rendering and Storybook location

```
src/
└── components
    ├──SeconadryNav
    │   ├── __tests__/
    │   ├── SeconadryNav.jsx
    │   ├── SeconadryNav.story.jsx
    │   └── SeconadryNav.css
    └── index.js
```

### Functional Tests

`SeconadryNav-tests` is available to test if secondary navigation renders correctly.

Closes #72 