### PR TITLE
🐛 Bug fix for style build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-scripts": "1.1.4"
   },
   "scripts": {
-    "tailwind:css": "tailwind build src/css/tailwind.src.css -c  tailwind.js -o src/css/tailwind.css",
+    "tailwind:css": "tailwind build src/tailwind.src.css -c  tailwind.js -o src/tailwind.css",
     "storybook": "NODE_ENV=testing start-storybook -p 9001 -c .storybook",
     "storybook:build": "NODE_ENV=testing build-storybook -c .storybook -o ./storybook-static/",
     "snapshot": "yarn storybook:build && percy-storybook --widths=320,1280 --minimum_height=2000",

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import propTypes from 'prop-types';
 import className from 'classnames';
 import Logo from '../Logo/Logo';
-import './Header.css';
 
 /**
  * The common Kids First navigation.


### PR DESCRIPTION
Fix CSS import order issue with the warning:
`@import must precede all other statements (besides @charset)`

- Remove duplicated css import
- Fix tailwind:css script

Fixes #93