### PR TITLE
🐛 Bug/113 header styling corrections

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -5,7 +5,19 @@
 }
 
 .Header--navigation {
-  @apply flex h-24 p-4 border-b-2;
+  @apply 
+    flex 
+    p-12
+    border-b-2;
+
+  .Header--logo{     
+     height: 65px;
+  }
+
+  .Button {
+    @apply mx-4;
+  }
+
 }
 
 .Navigation--buttons {
@@ -15,6 +27,3 @@
       w-full;
 }
 
-.Header--navigation .Button {
-  @apply mx-4;
-}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,14 +1,11 @@
 .Header {
-  @apply w-full
-      bg-white
-      py-20
-      px-12
-      border-b-2
-      border-lightGrey;
+  @apply 
+      w-full
+      bg-white;
 }
 
 .Header--navigation {
-  @apply flex h-24;
+  @apply flex h-24 p-4 border-b-2;
 }
 
 .Navigation--buttons {
@@ -19,5 +16,5 @@
 }
 
 .Header--navigation .Button {
-  @apply mx-8;
+  @apply mx-4;
 }


### PR DESCRIPTION
Addresses #113 

Somewhere along the line the header styles broke, i.e. way off from the previous production uikit release 0.3.1 and they were not caught before they were merged to `master`.

🕵️ the cause is likely due to major changes to the spacing system introduced in #87, when it was merged regression testing wasn't in place

This PR seeks to correct this by reverting some of the styles to their old values and leveraging the new spacing system to normalize padding and margins in the Header component. 

❗️ any other changes to the Header outside of corrections should be addressed with a new PR using the PR template