### PR TITLE
🐛 Bug/115 card styling diff

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -1,19 +1,16 @@
 .Card {
-  margin: 10px;
   @apply inline-block
         overflow-hidden 
         w-full
-        p-20
+        p-12
         bg-white
         rounded-sm
-        border
-        border-grey-lighter
+        shadow
         text-base
         font-normal;
 
   hr {
-    @apply my-20 
-            border
+    @apply border
             border-solid
             border-lightGrey;
   }


### PR DESCRIPTION
Addresses #115 

Somewhere along the line the Card styles changed evidenced by this diff https://percy.io/Kids-First-DRC/KF-UIkit/builds/1740019/view/113307234/1280?mode=diff&browser=chrome&snapshot=113307234
i.e. way off from the previous production uikit release 0.3.1 and they were not caught before they were merged to `master`.

🕵️ the cause is likely due to major changes to the spacing system introduced in #87, when it was merged regression testing wasn't in place

This PR seeks to correct this by reverting some of the styles to their old values and leveraging the new spacing system to normalize padding and margins in the Card component. 

❗️ any other changes to the Header outside of corrections should be addressed with a new PR using the PR template