### PR TITLE
♻️ Ignore percy in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,4 @@ jobs:
       # run tests!
       - run: ./node_modules/.bin/eslint src/
       - run: NODE_ENV=testing yarn test
-      - run: yarn snapshot
+      - run: set +e; yarn snapshot; true


### PR DESCRIPTION
Ignores failures from the percy snapshot command. Percy will still fail from its status check, but should not interfere with the unittest status.