### PR TITLE
🔧 Export bablified js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+ module.exports = require("./dist/main.js");


### PR DESCRIPTION
This exports the bablified js from the project root so that it is picked up instead of the es6 src.
It seems that jest in cra has a different babel config and won't run the node-modules through babel, unlike the dev server.