### PR TITLE
🔥 Remove lodash from Avatar

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -2,13 +2,12 @@ import React from 'react';
 import propTypes from 'prop-types';
 import classes from 'classnames';
 import md5 from 'md5';
-import { trim } from 'lodash';
 /**
  * Displays user profile avatar image with/withour user name
  */
 const Avatar = ({ className, size, userName, imgUrl, userEmail }) => {
   const gravatarUrl = userEmail
-    ? `https://www.gravatar.com/avatar/${md5(trim(userEmail.toLowerCase()))}?s=${size}`
+    ? `https://www.gravatar.com/avatar/${md5(userEmail.toLowerCase().trim())}?s=${size}`
     : null;
   const avatarClass = classes('Avatar', className);
   const avatarSize =


### PR DESCRIPTION
We don't export lodash as a dependency for our bundle, so its use in the Avatar was causing the build to fail.
We obviously don't need it to do `trim()`, and we should probably not introduce it to our dependency chain anyway given that it is mostly a collection of convenience functions.