### PR TITLE
👷 Ensure bundle builds without error in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,5 @@ jobs:
       # run tests!
       - run: ./node_modules/.bin/eslint src/
       - run: NODE_ENV=testing yarn test
+      - run: yarn build
       - run: set +e; yarn snapshot; true


### PR DESCRIPTION
Prevents issues like #129 from being merged.