### PR TITLE
👷 Bundle size status check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,8 @@ jobs:
       - run: ./node_modules/.bin/eslint src/
       - run: NODE_ENV=testing yarn test
       - run: yarn build
+      - run:
+          command: |
+            yarn add -D bundlesize
+            yarn run bundlesize
       - run: set +e; yarn snapshot; true

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "files": [
     "dist"
   ],
+  "bundlesize": [
+    {
+      "path": "./dist/*.js",
+      "maxSize": "3 MB"
+    },
+    {
+      "path": "./dist/*.css",
+      "maxSize": "1 MB"
+    }
+  ],
   "dependencies": {
     "chroma-js": "^2.0.3",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Runs a bundle size check that will report back with the size of our package to ensure that it doesn't get too out of control.