### PR TITLE
🐛 Fix grid prop "collapsed" to accept 'false' as its value

### DIFF
--- a/src/components/Grid/Grid.story.jsx
+++ b/src/components/Grid/Grid.story.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { range } from 'lodash';
-import { number, radios, boolean } from '@storybook/addon-knobs';
+import { number, select, boolean } from '@storybook/addon-knobs';
 import GridContainer from './GridContainer';
 
 const stories = storiesOf('Layout', module);
@@ -394,13 +394,7 @@ stories.add(
   () => (
     <div>
       <section className="hide-in-tests">
-        <GridContainer
-          collapsed={radios(
-            'collapse',
-            { rows: 'rows', cells: 'cells', all: true, none: false },
-            false,
-          )}
-        >
+        <GridContainer collapsed={select('Collapse', ['rows', 'cells', true, false], false)}>
           {range(1, 13).map(i => (
             <div className={`cell-${i} row-${i} h-12 text-white text-center border bg-grey`}>
               <p className="mt-0 pt-0">

--- a/src/components/Grid/Grid.story.jsx
+++ b/src/components/Grid/Grid.story.jsx
@@ -17,13 +17,13 @@ stories.add(
       <div>
         <section className="bg-grey p-12 hide-in-tests" style={{ width: 2000 }}>
           <GridContainer className="border bg-teal" {...{ fullWidth, centered }}>
-            {range(1, 13).map(() => (
-              <div className="cell-1 row-1 h-12 text-black text-center border bg-white">
+            {range(1, 13).map(i => (
+              <div className="cell-1 row-1 h-12 text-black text-center border bg-white" key={i}>
                 <p className="mt-0 pt-12 text-xs">60px</p>
               </div>
             ))}
-            {range(1, 13).map(() => (
-              <div className="cell-1 row-2 h-12 text-black text-center border bg-white">
+            {range(1, 13).map(i => (
+              <div className="cell-1 row-2 h-12 text-black text-center border bg-white" key={i}>
                 <p className="mt-0 pt-12 text-xs">60px</p>
               </div>
             ))}
@@ -32,38 +32,38 @@ stories.add(
         {process.env.STORYBOOK_PERCY_ENV ? (
           <section className="show-in-tests" style={{ width: 1280 }}>
             <GridContainer className="border bg-teal mb-20">
-              {range(1, 13).map(() => (
-                <div className="cell-1 row-1 h-12 text-black text-center border bg-white">
+              {range(1, 13).map(i => (
+                <div className="cell-1 row-1 h-12 text-black text-center border bg-white" key={i}>
                   <p className="mt-0 pt-12 text-xs">60px</p>
                 </div>
               ))}
-              {range(1, 13).map(() => (
-                <div className="cell-1 row-2 h-12 text-black text-center border bg-white">
+              {range(1, 13).map(i => (
+                <div className="cell-1 row-2 h-12 text-black text-center border bg-white" key={i}>
                   <p className="mt-0 pt-12 text-xs">60px</p>
                 </div>
               ))}
             </GridContainer>
             <GridContainer className="border bg-teal mb-20" fullWidth>
-              {range(1, 13).map(() => (
-                <div className="cell-1 row-1 h-12 text-black text-center border bg-white">
+              {range(1, 13).map(i => (
+                <div className="cell-1 row-1 h-12 text-black text-center border bg-white" key={i}>
                   <p className="mt-0 pt-12 text-xs">60px</p>
                 </div>
               ))}
-              {range(1, 13).map(() => (
-                <div className="cell-1 row-2 h-12 text-black text-center border bg-white">
+              {range(1, 13).map(i => (
+                <div className="cell-1 row-2 h-12 text-black text-center border bg-white" key={i}>
                   <p className="mt-0 pt-12 text-xs">60px</p>
                 </div>
               ))}
             </GridContainer>
 
             <GridContainer className="border bg-teal mb-20" centered={false}>
-              {range(1, 13).map(() => (
-                <div className="cell-1 row-1 h-12 text-black text-center border bg-white">
+              {range(1, 13).map(i => (
+                <div className="cell-1 row-1 h-12 text-black text-center border bg-white" key={i}>
                   <p className="mt-0 pt-12 text-xs">60px</p>
                 </div>
               ))}
-              {range(1, 13).map(() => (
-                <div className="cell-1 row-2 h-12 text-black text-center border bg-white">
+              {range(1, 13).map(i => (
+                <div className="cell-1 row-2 h-12 text-black text-center border bg-white" key={i}>
                   <p className="mt-0 pt-12 text-xs">60px</p>
                 </div>
               ))}
@@ -118,7 +118,10 @@ stories.add(
       <section>
         <GridContainer>
           {range(1, 13).map(i => (
-            <div className={`cell-${i} row-${i} h-12 text-white text-center border bg-grey`}>
+            <div
+              className={`cell-${i} row-${i} h-12 text-white text-center border bg-grey`}
+              key={i}
+            >
               <p className="mt-0 pt-12 text-xs">.cell-{i}</p>
             </div>
           ))}
@@ -233,7 +236,7 @@ stories.add(
               </p>
             </div>
             {range(1, 13).map(i => (
-              <div className="cell-1 row-2 h-12 text-white text-center border bg-grey">
+              <div className="cell-1 row-2 h-12 text-white text-center border bg-grey" key={i}>
                 <p className="mt-0 pt-0">
                   .cell-
                   {i}
@@ -253,7 +256,7 @@ stories.add(
             </div>
 
             {range(1, 13).map(i => (
-              <div className="cell-1 row-2 h-12 text-white text-center border bg-grey">
+              <div className="cell-1 row-2 h-12 text-white text-center border bg-grey" key={i}>
                 <p className="mt-0 pt-0">
                   .cell-
                   {i}
@@ -272,7 +275,7 @@ stories.add(
                 <p className="mt-0 pt-0">.cell-3-4</p>
               </div>
               {range(1, 13).map(i => (
-                <div className="cell-1 row-2 h-12 text-white text-center border bg-grey">
+                <div className="cell-1 row-2 h-12 text-white text-center border bg-grey" key={i}>
                   <p className="mt-0 pt-0">
                     .cell-
                     {i}
@@ -337,7 +340,10 @@ stories.add(
               </p>
             </div>
             {range(1, 12).map((i, idx) => (
-              <div className={`cell-6 row-${i + 1} h-12 text-white text-center border bg-grey`}>
+              <div
+                className={`cell-6 row-${i + 1} h-12 text-white text-center border bg-grey`}
+                key={i}
+              >
                 <p className="mt-0 pt-12 text-xs">
                   ({idx + 1}
                   ).row-
@@ -355,7 +361,10 @@ stories.add(
                 <p className="mt-0 pt-12 text-xs">.row-9 .cell-7-6</p>
               </div>
               {range(1, 12).map((i, idx) => (
-                <div className={`cell-6 row-${i + 1} h-12 text-white text-center border bg-grey`}>
+                <div
+                  className={`cell-6 row-${i + 1} h-12 text-white text-center border bg-grey`}
+                  key={i}
+                >
                   <p className="mt-0 pt-12 text-xs">
                     ({idx + 1}
                     ).row-
@@ -396,7 +405,10 @@ stories.add(
       <section className="hide-in-tests">
         <GridContainer collapsed={select('Collapse', ['rows', 'cells', true, false], false)}>
           {range(1, 13).map(i => (
-            <div className={`cell-${i} row-${i} h-12 text-white text-center border bg-grey`}>
+            <div
+              className={`cell-${i} row-${i} h-12 text-white text-center border bg-grey`}
+              key={i}
+            >
               <p className="mt-0 pt-0">
                 .cell-
                 {i}
@@ -405,7 +417,10 @@ stories.add(
           ))}
 
           {range(11, 0).map((i, idx) => (
-            <div className={`cell-${i} row-${idx + 1} h-12 text-white text-center border bg-grey`}>
+            <div
+              className={`cell-${i} row-${idx + 1} h-12 text-white text-center border bg-grey`}
+              key={i}
+            >
               <p className="mt-0 pt-0">
                 .cell-
                 {i}
@@ -503,7 +518,10 @@ stories.add(
             <p className="mt-0 pt-0">.cell-12</p>
             <GridContainer {...{ collapsed }}>
               {range(1, 10).map(i => (
-                <div className={`cell-${i} row-${i} h-12 text-white text-center border bg-blue`}>
+                <div
+                  className={`cell-${i} row-${i} h-12 text-white text-center border bg-blue`}
+                  key={i}
+                >
                   <p className="mt-0 pt-0">
                     .cell-
                     {i}
@@ -516,6 +534,7 @@ stories.add(
                   {range(1, 13).map(x => (
                     <div
                       className={`cell-${x} row-${x} h-12 text-white text-center border bg-purple`}
+                      key={x}
                     >
                       <p className="mt-0 pt-0">
                         .cell-
@@ -527,6 +546,7 @@ stories.add(
                     <div
                       className={`cell-${i} row-${idx +
                         1} h-12 text-white text-center border bg-purple`}
+                      key={i}
                     >
                       <p className="mt-0 pt-0">
                         .cell-

--- a/src/components/Grid/GridContainer.jsx
+++ b/src/components/Grid/GridContainer.jsx
@@ -27,7 +27,7 @@ GridContainer.propTypes = {
   /** Children elements. */
   children: PropTypes.node,
   /** Collapse margins and gutters. */
-  collapsed: PropTypes.oneOf([true, 'cells', 'rows']),
+  collapsed: PropTypes.oneOf([true, false, 'cells', 'rows']),
   /** wheter or not to apply margin: 0 auto; */
   centered: PropTypes.bool,
   /** wheter or not to apply max-width: 100%; */


### PR DESCRIPTION
Error message:
![image](https://user-images.githubusercontent.com/32206137/58657755-f8d34980-82ec-11e9-8e74-9e4ee518e28a.png)
Fixed by adding false to one of the 'collapsed' prop accepted value list.

Some minor fix on storybook:

- Change the knob type on layout gutters `/story/layout--gutters` from radio to selection. Previously, 'true` and `false` value are passed to prop as a string, now they are passed as a boolean value.
- Add key to all the list elements.

Closes #133 